### PR TITLE
Fix `getpid` call in Octave

### DIFF
--- a/io/tempmrcdir.m
+++ b/io/tempmrcdir.m
@@ -33,7 +33,11 @@ if ~exist('tmpdir','var')
     tmpdir='/scratch';
 end
 
-pid=feature('getpid');
+if isoctave()
+    pid = getpid();
+else
+    pid=feature('getpid');
+end
 
 fname = mfilename('fullpath');
 [pathstr,~,~] = fileparts(fname); % Find where the package installed.


### PR DESCRIPTION
In Octave, it's just plain old `getpid()`, as opposed to MATLAB's
`feature(getpid)`.