### PR TITLE
updates for obtaining consistent results with Python tests

### DIFF
--- a/basis/FPswfCoeffEval/FPSWF_t_example.m
+++ b/basis/FPswfCoeffEval/FPSWF_t_example.m
@@ -3,13 +3,13 @@ clear variables;
 close all;
 
 %% Load example dataset 
-load 70S_proj_10_s4     % Example with 10 projection images
+load 70S_proj_10_s4;     % Example with 10 projection images
 
 %% Define parameters
 beta = 1;
 L = 64;
 c = beta*pi*L;
-T = 1e1;
+T = 1.0;
 realFlag = 0;
 numChunks = 2;
 

--- a/basis/FPswfCoeffEval/FPSWF_t_example.m
+++ b/basis/FPswfCoeffEval/FPSWF_t_example.m
@@ -10,7 +10,7 @@ beta = 1;
 L = 64;
 c = beta*pi*L;
 T = 1.0;
-realFlag = 0;
+realFlag = 1;
 numChunks = 2;
 
 % - Choose tolerances

--- a/basis/FPswfCoeffEval/FPSWF_t_example.m
+++ b/basis/FPswfCoeffEval/FPSWF_t_example.m
@@ -1,0 +1,72 @@
+%clc;
+clear variables;
+close all;
+
+%% Load example dataset 
+load 70S_proj_10_s4     % Example with 10 projection images
+
+%% Define parameters
+beta = 1;
+L = 64;
+c = beta*pi*L;
+T = 1e1;
+realFlag = 0;
+numChunks = 2;
+
+% - Choose tolerances
+phiApproxErr = 1e-16;
+radialQuadErr = 1e-16;
+angularQuadErr = 1e-16;
+
+%% Generate quadrature nodes and weights
+% [quadRulePtsX,quadRulePtsY,quadRuleWts,radialQuadPts,quadRuleRadialWts,numAngularPts] = generatePswfQuad(4*L,2*c,phiApproxErr,radialQuadErr,angularQuadErr,realFlag);
+
+%% Generate PSWFs on the quadrature nodes
+% [ PSWF_mat_quad, Alpha_Nn, ~, ~ ] = PSWF_2D_gen_with_truncation( L, beta, eps, T, L*quadRulePtsX.', L*quadRulePtsY.' );
+
+%% Test orthonormality of PSWFs on disk using quadratures
+% orthonormalityTest = PSWF_mat_quad' * diag(quadRuleWts) * PSWF_mat_quad;
+% max(max(abs(triu(orthonormalityTest,1))))
+
+%% Generate rectangular grids 
+x_1d_grid = -1:(1/L):1;   % - Odd number of points
+%% x_1d_grid = -1:(1/L):(1-1/L);   % - Even number of points
+[x_2d_grid,y_2d_grid] = meshgrid(x_1d_grid,x_1d_grid);
+r_2d_grid = sqrt(x_2d_grid.^2 + y_2d_grid.^2);
+points_inside_the_circle = (r_2d_grid <= 1);
+image_height = numel(x_1d_grid);
+
+points_inside_the_circle_vec = reshape(points_inside_the_circle, image_height*image_height, 1);
+
+x_cartesian = x_2d_grid(points_inside_the_circle);
+y_cartesian = y_2d_grid(points_inside_the_circle);
+
+%% Prepare quadratures-based transform and evaluate spectrum 
+% USFFT_mat = exp(-1i*c*[quadRulePtsX.' quadRulePtsY.'] * [x_cartesian.'; y_cartesian.']);
+% G = c/(2*pi*L) * PSWF_mat_quad' * bsxfun(@times,quadRuleWts.',USFFT_mat);
+% 
+% spectrumTest = G*G';
+% s = eig(spectrumTest);
+% figure; bar(abs(s));
+
+%% generate images
+%%nImages = 2e4;
+%%images = randn(2*L,2*L,nImages);
+images = projections;
+
+%% Compute coefficients using standard inner product and also using quadratures
+[ coeffVecQuadFast, normalizedPSWF_mat] = fastPswfCoeffEval( images, x_cartesian, y_cartesian, L, beta, T, numChunks, realFlag );
+
+images = reshape(images,size(images,1)*size(images,2),size(images,3));
+% images = images(points_inside_the_circle(:),:);
+images = images(points_inside_the_circle(:),:);
+
+coeffVecStandard = normalizedPSWF_mat' * images;
+
+% coeffVecQuad = G * images;
+
+%% Compare resulting expansion coefficients of different methods
+% err1 = max(max(abs(coeffVecQuadFast - coeffVecQuad)))
+% err2 = max(max(abs(coeffVecQuadFast - coeffVecStandard)))
+err2 = mean(max(abs(coeffVecQuadFast - coeffVecStandard)))
+

--- a/basis/FPswfCoeffEval/computeNfft.m
+++ b/basis/FPswfCoeffEval/computeNfft.m
@@ -1,7 +1,7 @@
 function [ images_nufft ] = computeNfft( images, usFftPts, L, points_inside_the_circle)
 % This function computes the NFFT of the images at the designated nodes
 
-images_full = zeros((2*L)^2, size(images, 2));
+images_full = zeros((2*L+1)^2, size(images, 2));
 images_full(points_inside_the_circle,:) = images;
 images_full = vec_to_im(images_full);
 

--- a/basis/FPswfCoeffEval/computeNfft.m
+++ b/basis/FPswfCoeffEval/computeNfft.m
@@ -8,6 +8,5 @@ images_full = vec_to_im(images_full);
 % NOTE: For backwards compatibility, we have to transpose the x and y axes
 % here, but this is probably not the right thing to do.
 images_nufft = nufft2(permute(images_full, [2 1 3]), usFftPts.');
-
 end
 

--- a/basis/FPswfCoeffEval/fastPswfCoeffEval.m
+++ b/basis/FPswfCoeffEval/fastPswfCoeffEval.m
@@ -17,14 +17,17 @@ angularQuadErr = 1e-16;
 [quadRulePtsX,quadRulePtsY,~,radialQuadPts,quadRuleRadialWts,numAngularPts] = generatePswfQuad(4*L,2*c,phiApproxErr,radialQuadErr,angularQuadErr,realFlag);
 
 %% Generate rectangular grids 
-% x_1d_grid = -1:(1/L):1;   % - Odd number of points
-x_1d_grid = -1:(1/L):(1-1/L);   % - Even number of points
+x_1d_grid = -1:(1/L):1;   % - Odd number of points
+%% x_1d_grid = -1:(1/L):(1-1/L);   % - Even number of points
 [x_2d_grid,y_2d_grid] = meshgrid(x_1d_grid,x_1d_grid);
 r_2d_grid = sqrt(x_2d_grid.^2 + y_2d_grid.^2);
 points_inside_the_circle = (r_2d_grid <= 1);
+image_height = numel(x_1d_grid);
+points_inside_the_circle_vec = reshape(points_inside_the_circle, image_height*image_height, 1);
 
 %% Take only samples inside the unite disk
-images = images(points_inside_the_circle(:),:);
+%% images = images(points_inside_the_circle(:),:);
+images = images(points_inside_the_circle_vec(:),:);
 
 %% Generate PSWF basis on Cartesian grid 
 [ normalizedPSWF_mat, Alpha_Nn, ang_freqs, rad_freqs ] = PSWF_basis_gen_v3( L+1, L, beta, phiApproxErr, T, L*x, L*y );
@@ -50,7 +53,7 @@ for i = 1:numChunks
 end
 % - Compute NFFT and expansion coefficients
 parfor i = 1:numChunks
-    nfftRes = computeNfft( imagesCell{i}, usFftPts, L, points_inside_the_circle);
+    nfftRes = computeNfft( imagesCell{i}, usFftPts, L, points_inside_the_circle_vec);
     coeffVecQuadFast_cell{i} = fastPswfIntegration(nfftRes ,c ,L, numAngularPts, ang_freq, radialQuadPts, quadRuleRadialWts, PSWF_radial_quad, realFlag);
     imagesCell{i} = [];
 end

--- a/basis/pswf/PSWF_2D.m
+++ b/basis/pswf/PSWF_2D.m
@@ -33,6 +33,7 @@ approx_len = n + 1 + d_decay_idx_counter;
 %% Funcion defenitions
 Pn = @(n,alpha,beta,x) j_polynomial(length(x),n,alpha,beta,x);
 
+
 %% Generate Matrix for calculation of d_k coefficients
 B_N = Generate_BN_mat(N,c,approx_len);
 [d_vec, xi] = eig(B_N);
@@ -43,6 +44,17 @@ d_vec = d_vec(:,idx);
 for i=1:approx_len
     xi(i,i) = xiVec(i);
 end
+
+%% Change the sign of eigen vectors to make consistent with Python version
+%% for example, using N = 0; c = 1.0*pi*64; approx_len=182; for BN_mat.
+
+[~, maxi] = max(abs(d_vec),[],1);
+bmat = zeros(approx_len, approx_len);
+for i=1:approx_len
+    bmat(:, i) = sign(d_vec(maxi(i),i));
+end
+d_vec = d_vec .* bmat;
+
 
 %% Compare true decay of d's with approximation function
 % d_decay_compare = [abs(d_vec((n+2):end,n+1)./d_vec((n+1):(end-1),n+1)),d_decay_approx_fun(N,n,c,0:(approx_len-2-n)).'];

--- a/basis/pswf/PSWF_2D.m
+++ b/basis/pswf/PSWF_2D.m
@@ -101,7 +101,7 @@ alpha_N = lambda_N*2*pi*((1i)^N) / sqrt(c);
 %% Compute PSFW's on the grid inside the disk
 j=0:(approx_len-1);
 T_radial_part_mat = @(x,N,j,approx_len) ((x.^N)*((2*(2*j+N+1)).^(1/2))) .* Pn(approx_len-1,N,0,1-2*x.^2); % - These are the ordinairy T's divided by x^(1/2).
-d_vec = bsxfun(@times,d_vec,sign(sign(diag(d_vec).')+0.5));    %Fix the signs so that all functions begin positive.
+%d_vec = bsxfun(@times,d_vec,sign(sign(diag(d_vec).')+0.5));    %Fix the signs so that all functions begin positive.
 R_radial_part_mat = T_radial_part_mat(radial_eval_pts,N,j,approx_len) * d_vec(:,1:(n+1));
 % R_radial_part_mat = R_radial_part_mat .* (ones(length(radial_eval_pts),1)*sign(phi(100,:)));    %Fix the signs so that all functions begin positive.
 

--- a/basis/pswf/PSWF_t_example.m
+++ b/basis/pswf/PSWF_t_example.m
@@ -8,7 +8,7 @@ load 70S_proj_10_s4     % Example with 10 projection images
 L = 64;         % Image resolution: (2L+1)x(2L+1) samples on a Cartesian grid
 beta = 1;       % Bandlimit ratio (between 0 and 1) - smaller values stand for greater oversampling
 c = beta*pi*L;  % Bandlimit 
-T = 1e-3;       % Truncation parameter
+T = 1.0;       % Truncation parameter
 realFlag = 1;   % Flag indicating whether the data is assumed to be real-valued
 
 % For all parameters - see more details in the function pswf_t_f. Also, see the

--- a/common/qrand.m
+++ b/common/qrand.m
@@ -13,7 +13,7 @@ function q=qrand(K)
 % same group elements, so we take a>=0.
 %
 
-q = randn2(4,K);
+q = randn_py(4,K);
 %q(:,1) = [0;1;0;1];
 l2_norm = sqrt(q(1,:).^2 + q(2,:).^2 + q(3,:).^2 + q(4,:).^2);
 for i=1:4

--- a/common/qrand.m
+++ b/common/qrand.m
@@ -13,7 +13,7 @@ function q=qrand(K)
 % same group elements, so we take a>=0.
 %
 
-q = randn(4,K);
+q = randn2(4,K);
 %q(:,1) = [0;1;0;1];
 l2_norm = sqrt(q(1,:).^2 + q(2,:).^2 + q(3,:).^2 + q(4,:).^2);
 for i=1:4

--- a/common/randn2.m
+++ b/common/randn2.m
@@ -1,0 +1,7 @@
+function [ output ] = randn2(varargin)
+% randn2  Calls rand and applies inverse transform sampling to the output.
+ 
+output = rand(varargin{:});
+output = sqrt(2) * erfinv(2 * output - 1);
+ 
+end

--- a/common/randn_py.m
+++ b/common/randn_py.m
@@ -1,4 +1,4 @@
-function [ output ] = randn2(varargin)
+function [ output ] = randn_py(varargin)
 % randn2  Calls rand and applies inverse transform sampling to the output.
  
 output = rand(varargin{:});

--- a/examples/example_003_pytest.m
+++ b/examples/example_003_pytest.m
@@ -6,8 +6,8 @@
 %%% Parameters %%%
 
 L = 8;                 % Size of images
-n = 32;               % Number of images n
-% n = 1024;               % Number of images n
+% n = 32;               % Number of images n
+n = 1024;               % Number of images n
 SNR = 1;                % Signal-to-noise ratio of images.
 
 pixel_size = 5;         % Pixel size of the images (in angstroms).

--- a/examples/example_003_pytest.m
+++ b/examples/example_003_pytest.m
@@ -6,8 +6,8 @@
 %%% Parameters %%%
 
 L = 8;                 % Size of images
-n = 1024;               % Number of images
-
+n = 32;               % Number of images n
+% n = 1024;               % Number of images n
 SNR = 1;                % Signal-to-noise ratio of images.
 
 pixel_size = 5;         % Pixel size of the images (in angstroms).
@@ -112,8 +112,17 @@ covar_coeff = fb_rot_covar(coeff_clean, mean_coeff, basis);
 % the estimated mean and the variance of the noise are needed. Again, the
 % covariance matrix estimate is provided in block diagonal form.
 mean_coeff_est = fb_rot_mean_ctf(coeff, h_fb, h_idx, basis);
+% covar_coeff_est = fb_rot_covar_ctf(coeff, h_fb, h_idx, ...
+%    mean_coeff_est, noise_var, basis);
+
+covar_est_opt = struct();
+covar_est_opt = fill_struct(covar_est_opt, ...
+        'shrinker', 'frobenius_norm', ...
+        'verbose', 0, ...
+        'max_iter', 250, ...
+        'rel_tolerance', 1e-12);
 covar_coeff_est = fb_rot_covar_ctf(coeff, h_fb, h_idx, ...
-    mean_coeff_est, noise_var, basis);
+    mean_coeff_est, noise_var, basis, covar_est_opt);
 
 % Estimate the Fourier-Bessel coefficients of the underlying images using a
 % Wiener filter. This Wiener filter is calculated from the estimated mean,

--- a/examples/example_003_pytest.m
+++ b/examples/example_003_pytest.m
@@ -80,7 +80,7 @@ end
 power_clean = tnorm(proj_ctf_clean)^2/numel(proj_ctf_clean);
 noise_var = power_clean/SNR;
 initstate(0);
-proj = proj_ctf_clean + sqrt(noise_var)*randn2(size(proj_ctf_clean));
+proj = proj_ctf_clean + sqrt(noise_var)*randn_py(size(proj_ctf_clean));
 
 %%% Estimation %%%
 

--- a/examples/example_003_pytest.m
+++ b/examples/example_003_pytest.m
@@ -1,0 +1,145 @@
+% This script illustrates the covariance Wiener filtering functionality of the
+% ASPIRE toolbox, implemented by estimating the covariance of the unfiltered
+% images in a Fourier-Bessel basis and applying the Wiener filter induced by
+% that covariance matrix.
+
+%%% Parameters %%%
+
+L = 8;                 % Size of images
+n = 1024;               % Number of images
+
+SNR = 1;                % Signal-to-noise ratio of images.
+
+pixel_size = 5;         % Pixel size of the images (in angstroms).
+
+defocus_min = 1.5e4;    % Minimum defocus value (in angstroms).
+defocus_max = 2.5e4;    % Maximum defocus value (in angstroms).
+defocus_ct = 7;         % Number of defocus groups.
+
+basis = ffb_basis(L*ones(1, 2), L, 1);
+
+% Initialize the random number generator.
+initstate(0);
+
+%%% Simulation setup %%%
+
+% Set up the arrays to hold the CTFs, both as 2D filters and as block diagonal
+% matrices in the Fourier-Bessel basis.
+h = zeros([L*ones(1, 2) defocus_ct]);
+h_fb = cell(1, defocus_ct);
+
+% Set up the default CTF parameters. The only one we vary is the defocus.
+ctf_params = struct();
+ctf_params.voltage = 200;
+ctf_params.spherical_aberration = 2;
+ctf_params.amplitude_contrast = 0.1;
+
+% Calculate the defocus values which will define the CTFs.
+defocus = linspace(defocus_min, defocus_max, defocus_ct);
+
+% For each defocus, generate a function handle representing the CTF as a
+% function of radial frequency, then evaluate that on a grid and calculate
+% its block diagonal representation in the Fourier-Bessel basis.
+for k = 1:numel(defocus)
+    ctf_params.defocus = defocus(k);
+
+    h_fun = cryo_radial_ctf_handle(pixel_size, ctf_params);
+
+    h(:,:,k) = radial_fun_to_image(h_fun, L);
+    h_fb{k} = radial_filter_to_fb_mat(h_fun, basis);
+end
+
+% Randomly assign a CTF to each image.
+h_idx = randi(numel(defocus), [1 n]);
+
+% Load the 'cleanrib' volume, corresponding to the experimentally obtained EM
+% map of a 70S ribosome.
+root = aspire_root();
+file_name = fullfile(root, 'projections', 'simulation', 'maps', 'cleanrib.mat');
+f = load(file_name);
+vol = cryo_downsample(f.volref, L*ones(1, 3));
+
+% Generate random rotations and project.
+initstate(0);
+rots = rand_rots(n);
+proj_clean = cryo_project(vol, rots);
+
+% Prepare an array to hold the filtered projections.
+proj_ctf_clean = zeros(size(proj_clean), class(proj_clean));
+
+% For each defocus group, find the images that are assigned to that CTF, and
+% filter them.
+for k = 1:numel(defocus)
+    mask = find(h_idx == k);
+
+    proj_ctf_clean(:,:,mask) = im_filter(proj_clean(:,:,mask), h(:,:,k));
+end
+
+% Add noise at the desired SNR to the filtered images to get our final
+% projections.
+power_clean = tnorm(proj_ctf_clean)^2/numel(proj_ctf_clean);
+noise_var = power_clean/SNR;
+initstate(0);
+proj = proj_ctf_clean + sqrt(noise_var)*randn2(size(proj_ctf_clean));
+
+%%% Estimation %%%
+
+% Expand the images, both clean and noisy, in the Fourier-Bessel basis. This
+% can be done exactly (that is, up to numerical precision) using the
+% `basis.expand` function, but for our purposes, an approximation will do.
+% Since the basis is close to orthonormal, we may approximate the exact
+% expansion by applying the adjoint of the evaluation mapping using 
+% `basis.evaluate_t`.
+coeff_clean = basis.evaluate_t(proj_clean);
+coeff = basis.evaluate_t(proj);
+
+% Given the clean Fourier-Bessel coefficients, we can estimate the symmetric
+% mean and covariance. Note that these are not the same as the sample mean and
+% covariance, since these functions use the rotational and reflectional
+% symmetries of the distribution to constrain to further constrain the
+% estimate. Note that the covariance matrix estimate is not a full matrix,
+% but is block diagonal. This form is a consequence of the symmetry
+% constraints, so to reduce space, only the diagonal blocks are stored. The
+% mean and covariance estimates will allow us to evaluate the mean and
+% covariance estimates from the filtered, noisy data, later.
+mean_coeff = fb_rot_mean(coeff_clean, basis);
+covar_coeff = fb_rot_covar(coeff_clean, mean_coeff, basis);
+
+% We now estimate the mean and covariance from the Fourier-Bessel
+% coefficients of the noisy, filtered images. These functions take into
+% account the filters applied to each image to undo their effect on the
+% estimates. For the covariance estimation, the additional information of
+% the estimated mean and the variance of the noise are needed. Again, the
+% covariance matrix estimate is provided in block diagonal form.
+mean_coeff_est = fb_rot_mean_ctf(coeff, h_fb, h_idx, basis);
+covar_coeff_est = fb_rot_covar_ctf(coeff, h_fb, h_idx, ...
+    mean_coeff_est, noise_var, basis);
+
+% Estimate the Fourier-Bessel coefficients of the underlying images using a
+% Wiener filter. This Wiener filter is calculated from the estimated mean,
+% covariance, and the variance of the noise. The resulting estimator has
+% the lowest expected mean square error out of all linear estimators.
+coeff_est = fb_rot_wiener_ctf(coeff, h_fb, h_idx, mean_coeff_est, ...
+    covar_coeff_est, noise_var, basis);
+
+% Convert Fourier-Bessel coefficients back into 2D images.
+proj_est = basis.evaluate(coeff_est);
+
+%%% Evaluate results %%%
+
+% Calculate the difference between the estimated covariance and the "true"
+% covariance estimated from the clean Fourier-Bessel coefficients.
+covar_coeff_diff = blk_diag_add(covar_coeff, ...
+    blk_diag_mult(-1, covar_coeff_est));
+
+% Calculate the deviation between the clean estimates and those obtained from
+% the noisy, filtered images.
+diff_mean = norm(mean_coeff_est-mean_coeff)/norm(mean_coeff);
+diff_covar = blk_diag_norm(covar_coeff_diff)/blk_diag_norm(covar_coeff);
+
+% Calculate the normalized RMSE of the estimated images.
+nrmse_ims = tnorm(proj_est-proj_clean)/tnorm(proj_clean);
+
+fprintf('%-50s%20g\n', 'Deviation of the noisy mean estimate:', diff_mean);
+fprintf('%-50s%20g\n', 'Deviation of the noisy covariance estimate:', diff_covar);
+fprintf('%-50s%20g\n', 'Estimated images normalized RMSE:', nrmse_ims);


### PR DESCRIPTION
This PR adds several updates to obtain consistent results for testing Python codes such as Cov2d and PSWF methods.  The major changes are listed as below: 
1) add the randn_py.m function to be consistent with Python package.
2) create a separate example for cov2d which can lead the same answer with Python version. 
3) modify the PSWF2D codes and examples to be consistent between the direct and the fast implementations and also between the Matlab and the Python codes. 

